### PR TITLE
콘테스트 API 매핑   📬 API ✨ Feature

### DIFF
--- a/src/api/contestApi.js
+++ b/src/api/contestApi.js
@@ -1,0 +1,87 @@
+import { apiClient } from './apiClient';
+
+export const fetchCurrentContest = async () => {
+    try {
+        const { data } = await apiClient.get('/api/contests');
+        return data.response;
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
+};
+
+export const fetchContestDetails = async (contestId) => {
+    try {
+        const { data } = await apiClient.get(`/api/contests/${contestId}`);
+        return data.response;
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+};
+
+export const fetchContestPayments = async (startDate, endDate) => {
+    try {
+        const { data } = await apiClient.post('/api/contests/payment', {
+            startDate,
+            endDate,
+        });
+        return data.response;
+    } catch (error) {
+        console.error(error);
+        return [];
+    }
+};
+
+export const postContestEntry = async (data) => {
+    try {
+        const res = await apiClient.post('/api/posts', data);
+        return res.response;
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+};
+
+export const checkContestParticipation = async (contestId) => {
+    try {
+        const { data } = await apiClient.get(`/api/contests/${contestId}/check`);
+        return data.response;
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+};
+
+export const getContestPosts = async (contestId, page, size) => {
+    try {
+        const { data } = await apiClient.get(`/api/contests/${contestId}/posts`, {
+            params: { page, size },
+        });
+        return data.response;
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+};
+
+export const deletePost = async (postId) => {
+    try {
+        const { data } = await apiClient.delete(`/api/posts/${postId}`);
+        return data.response;
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+};
+
+export const likePost = async (postId) => {
+    const { data } = await apiClient.post(`/api/posts/${postId}/like`);
+    return data.response;
+};
+
+export const unlikePost = async (postId) => {
+    const { data } = await apiClient.delete(`/api/posts/${postId}/like`);
+    return data.response;
+};
+

--- a/src/components/Contest/Feed.jsx
+++ b/src/components/Contest/Feed.jsx
@@ -1,6 +1,7 @@
 import { Box, Typography, IconButton } from '@mui/material';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
+import CloseIcon from '@mui/icons-material/Close';
 
 const Feed = ({
   imageUrl,
@@ -8,18 +9,38 @@ const Feed = ({
   nickname,
   explanation,
   isLiked,
-  onClick,
+  onClick, deleteButton,
+    onLikeToggle,
 }) => {
-  return (
-    <Box
-      sx={{
-        width: '100%',
-        border: '1px solid',
-        borderColor: 'n4.main',
-        borderRadius: '10px',
-      }}
-      onClick={onClick}
-    >
+    return (
+        <Box
+            sx={{
+                width: '100%',
+                border: '1px solid',
+                borderColor: 'n4.main',
+                borderRadius: '10px',
+                position: 'relative',
+            }}
+            onClick={onClick}
+        >
+            {/* 삭제 버튼 */}
+            {deleteButton && (
+                <IconButton
+                    sx={{
+                        position: 'absolute',
+                        top: 8,
+                        right: 8,
+                        backgroundColor: 'white',
+                        '&:hover': { backgroundColor: 'delete.main', color: 'white' },
+                    }}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        deleteButton();
+                    }}
+                >
+                    <CloseIcon />
+                </IconButton>
+            )}
       {/* 상단 사용자 정보 */}
       <Box display="flex" alignItems="center" mb={2} ml={2} mt={2}>
         <img
@@ -68,6 +89,7 @@ const Feed = ({
           onClick={(e) => {
             e.stopPropagation();
             // 좋아요 토글 로직
+              onLikeToggle();
           }}
         >
           {isLiked ? (

--- a/src/pages/Contest/Contest.jsx
+++ b/src/pages/Contest/Contest.jsx
@@ -2,21 +2,59 @@ import { DetailHeader } from '@/components/Common/DetailHeader/DetailHeader';
 import { Box, Typography } from '@mui/material';
 import Button from '@components/Common/Button/Button';
 import { useNavigate } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import {useState, useEffect, useCallback} from 'react';
 import Feed from '@components/Contest/Feed';
 import { Modal } from '@/components/Common/Modal/Modal';
 import WinnerProfile from '@components/Contest/WinnerProfile';
+import {
+  checkContestParticipation,
+  deletePost, fetchContestDetails,
+  fetchCurrentContest,
+  getContestPosts, likePost,
+  unlikePost
+} from "@/api/contestApi.js";
 
 const Contest = () => {
   const navigate = useNavigate();
   const [participatedGroomers, setParticipatedGroomers] = useState([]);
+  const [currentContest, setCurrentContest] = useState(null);
+  const [contestDetails, setContestDetails] = useState(null);
+  const [posts, setPosts] = useState([]);
+  const [page, setPage] = useState(0);
+  const [isLastPage, setIsLastPage] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const tempLoginUserId = 1;
+
+  // useEffect(() => {
+  //   // localStorage에서 참여한 미용사 목록 가져오기
+  //   const participated = JSON.parse(
+  //     localStorage.getItem('participatedGroomers') || '[]'
+  //   );
+  //   setParticipatedGroomers(participated);
+  // }, []);
 
   useEffect(() => {
-    // localStorage에서 참여한 미용사 목록 가져오기
-    const participated = JSON.parse(
-      localStorage.getItem('participatedGroomers') || '[]'
-    );
-    setParticipatedGroomers(participated);
+    const loadContestInfo = async () => {
+      try {
+        const contest = await fetchCurrentContest();
+        console.log("contestInfo:", contest);
+        if (contest) {
+          setCurrentContest(contest);
+          setPosts([]);
+          setPage(0);
+          setIsLastPage(false);
+
+          const details = await fetchContestDetails(contest.contestId);
+          console.log("details:", details);
+          setContestDetails(details);
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    loadContestInfo();
   }, []);
 
   const handleDelete = () => {
@@ -24,43 +62,148 @@ const Contest = () => {
     setParticipatedGroomers([]);
   };
 
-  // 예시 데이터
-  const contestEntries = [
-    {
-      id: 1,
-      imageUrl: '/images/dog.png',
-      userProfile: '/images/default-dog-profile.png',
-      nickname: '홍길동',
-      explanation: '자랑자랑자랑우리강아지너무귀엽지대박이지',
-      isLiked: true,
-    },
-    {
-      id: 2,
-      imageUrl: '/images/dog.png',
-      userProfile: '/images/default-dog-profile.png',
-      nickname: '이길동',
-      explanation: '자랑자랑자랑우리강아지너무귀엽지대박이지',
-      isLiked: false,
-    },
+  const fetchPosts = useCallback(async () => {
+    if (isLoading || isLastPage || !currentContest) return;
 
-    {
-      id: 3,
-      imageUrl: '/images/dog.png',
-      userProfile: '/images/default-dog-profile.png',
-      nickname: '김길동',
-      explanation: '자랑자랑자랑우리강아지너무귀엽지대박이지',
-      isLiked: false,
-    },
+    setIsLoading(true);
+    try {
+      const data = await getContestPosts(currentContest.contestId, page, 3);
+      setPosts((prevPosts) => [...prevPosts, ...data.content]);
+      setIsLastPage(data.last);
+      setPage((prevPage) => prevPage + 1);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoading, isLastPage, currentContest, page]);
 
-    {
-      id: 4,
-      imageUrl: '/images/dog.png',
-      userProfile: '/images/default-dog-profile.png',
-      nickname: '박길동',
-      explanation: '자랑자랑자랑우리강아지너무귀엽지대박이지',
-      isLiked: false,
-    },
-  ];
+  useEffect(() => {
+    if (currentContest && page === 0) {
+      fetchPosts();
+    }
+  }, [currentContest, fetchPosts]);
+
+  const handleParticipation = async () => {
+    try {
+      const response = await checkContestParticipation(currentContest.contestId);
+
+      if (response.already_participated) {
+        alert('이미 참여한 콘테스트입니다! 중복 참여는 불가능합니다.');
+      } else {
+        navigate('/contest/entry', {
+          state: {
+            startedAt: currentContest.startedAt,
+            endAt: currentContest.endAt,
+            contestId: currentContest.contestId,
+          },
+        });
+      }
+    } catch (error) {
+      console.error(error);
+      alert('참여 여부 확인 중 문제가 발생했습니다. 다시 시도해주세요.');
+    }
+  };
+
+  const handleDeletePost = async (postId) => {
+    try {
+      const response = await deletePost(postId);
+      if (response === "포스트 삭제가 완료되었습니다.") {
+        alert("포스트가 삭제되었습니다.");
+        setPosts((prevPosts) => prevPosts.filter((post) => post.postId !== postId));
+      } else {
+        alert("포스트 삭제 중 문제가 발생했습니다.");
+      }
+    } catch (error) {
+      console.error(error);
+      alert("포스트 삭제 중 문제가 발생했습니다.");
+    }
+  };
+
+  const handleScroll = useCallback(() => {
+    const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+
+    if (
+        scrollTop + clientHeight >= scrollHeight &&
+        !isLoading &&
+        !isLastPage &&
+        currentContest
+    ) {
+      fetchPosts();
+    }
+  }, [isLoading, isLastPage, currentContest, fetchPosts]);
+
+  useEffect(() => {
+    let timer;
+    const debouncedScroll = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => handleScroll(), 150);
+    };
+
+    window.addEventListener('scroll', debouncedScroll);
+    return () => {
+      window.removeEventListener('scroll', debouncedScroll);
+      if (timer) clearTimeout(timer);
+    };
+  }, [handleScroll]);
+
+  const handleLikeToggle = async (postId, isLiked) => {
+    try {
+      if (isLiked) {
+        await unlikePost(postId);
+      } else {
+        await likePost(postId);
+      }
+
+      setPosts((prevPosts) =>
+        prevPosts.map((post) =>
+          post.postId === postId
+            ? { ...post, liked: !isLiked }
+            :post
+        )
+      );
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  // // 예시 데이터
+  // const contestEntries = [
+  //   {
+  //     id: 1,
+  //     imageUrl: '/images/dog.png',
+  //     userProfile: '/images/default-dog-profile.png',
+  //     nickname: '홍길동',
+  //     explanation: '자랑자랑자랑우리강아지너무귀엽지대박이지',
+  //     isLiked: true,
+  //   },
+  //   {
+  //     id: 2,
+  //     imageUrl: '/images/dog.png',
+  //     userProfile: '/images/default-dog-profile.png',
+  //     nickname: '이길동',
+  //     explanation: '자랑자랑자랑우리강아지너무귀엽지대박이지',
+  //     isLiked: false,
+  //   },
+  //
+  //   {
+  //     id: 3,
+  //     imageUrl: '/images/dog.png',
+  //     userProfile: '/images/default-dog-profile.png',
+  //     nickname: '김길동',
+  //     explanation: '자랑자랑자랑우리강아지너무귀엽지대박이지',
+  //     isLiked: false,
+  //   },
+  //
+  //   {
+  //     id: 4,
+  //     imageUrl: '/images/dog.png',
+  //     userProfile: '/images/default-dog-profile.png',
+  //     nickname: '박길동',
+  //     explanation: '자랑자랑자랑우리강아지너무귀엽지대박이지',
+  //     isLiked: false,
+  //   },
+  // ];
 
   return (
     <div>
@@ -74,7 +217,11 @@ const Contest = () => {
             강아지의 변신을 책임진 미용사님은 누구?{' '}
             <Box
               component="span"
-              onClick={() => navigate('/salonprofile')}
+              onClick={() =>
+                  contestDetails?.recentWinner?.groomerProfileId
+                      ? navigate(`/salonprofile/${contestDetails.recentWinner.groomerProfileId}`)
+                      : alert('우승자 정보가 없습니다.')
+              }
               sx={{
                 cursor: 'pointer',
                 '&:hover': { textDecoration: 'underline' },
@@ -83,11 +230,15 @@ const Contest = () => {
               프로필 보러 가기
             </Box>
           </Box>
-          <WinnerProfile
-            name="길동이네"
-            profileImage="images/default-groomer-profile.png"
-            showVotes={false}
-          />
+          {contestDetails?.recentWinner ? (
+              <WinnerProfile
+                  name={contestDetails.recentWinner.dogName || '알 수 없는 강아지 이름'}
+                  profileImage={contestDetails.recentWinner.imageUrl || '/images/default-image.jpg'}
+                  showVotes={false}
+              />
+          ) : (
+              <Typography>우승자 정보가 없습니다.</Typography>
+          )}
           {/* 참여 버튼 */}
           <Box display="flex" justifyContent="center" mt={5} mb={5}>
             {participatedGroomers.length > 0 ? (
@@ -105,7 +256,7 @@ const Contest = () => {
                 label="참여하기"
                 backgroundColor="primary"
                 size="large"
-                onClick={() => navigate('/contest/entry')}
+                onClick={handleParticipation}
               />
             )}
           </Box>
@@ -131,15 +282,23 @@ const Contest = () => {
                 gap: 4,
               }}
             >
-              {contestEntries.map((entry) => (
-                <Feed
-                  key={entry.id}
-                  imageUrl={entry.imageUrl}
-                  nickname={entry.nickname}
-                  explanation={entry.explanation}
-                  isLiked={entry.isLiked}
-                />
+              {posts.map((post) => (
+                  <Feed
+                      key={post.postId}
+                      imageUrl={post.imageUrl}
+                      nickname={post.dogName}
+                      explanation={post.description}
+                      isLiked={post.liked}
+                      deleteButton={
+                        post.userId === tempLoginUserId
+                            ? () => handleDeletePost(post.postId)
+                            : null
+                      }
+                      onLikeToggle={() => handleLikeToggle(post.postId, post.liked)}
+                  />
               ))}
+              {isLoading && <Typography>로딩 중...</Typography>}
+              {isLastPage && <Typography>더 이상 게시물이 없습니다.</Typography>}
             </Box>
           </Box>{' '}
         </Box>

--- a/src/pages/Contest/ContestEntry.jsx
+++ b/src/pages/Contest/ContestEntry.jsx
@@ -1,233 +1,336 @@
-import { SurveyHeader } from '@/components/Common/SurveyHeader/SurveyHeader';
-import { Box, Typography, Container } from '@mui/material';
+import {SurveyHeader} from '@/components/Common/SurveyHeader/SurveyHeader';
+import {Box, Typography, Container} from '@mui/material';
 import Button from '@components/Common/Button/Button';
-import { useState } from 'react';
+import {useEffect, useState} from 'react';
 import ImageUploadIcon from '@mui/icons-material/Add';
-import { useNavigate } from 'react-router-dom';
+import {useLocation, useNavigate} from 'react-router-dom';
 import InputText from '@/components/Common/InputText/InputText';
+import {fetchContestPayments, postContestEntry} from "@/api/contestApi.js";
+import {uploadImage} from "@/api/image.js";
 
 const ContestEntry = () => {
-  const navigate = useNavigate();
-  const [petName, setPetName] = useState('');
-  const [explanation, setExplanation] = useState('');
-  const [step, setStep] = useState(1);
-  const [selectedGroomer, setSelectedGroomer] = useState(null);
-  const [selectedImage, setSelectedImage] = useState(null);
-  const handleBack = () => {
-    if (step > 1) {
-      setStep(step - 1);
-    } else {
-      navigate(-1);
-    }
-  };
-  const handleContestSubmit = () => {
-    const participationInfo = {
-      groomerId: selectedGroomer.id,
-      groomerName: selectedGroomer.name,
-      petName,
-      explanation,
-      image: selectedImage,
-      date: new Date().toISOString(),
+        const navigate = useNavigate();
+        const location = useLocation();
+        const {startedAt, endAt, contestId} = location.state || {};
+        const [payments, setPayments] = useState([]);
+
+        const [petName, setPetName] = useState('');
+        const [explanation, setExplanation] = useState('');
+        const [step, setStep] = useState(1);
+        const [selectedGroomer, setSelectedGroomer] = useState(null);
+        const [selectedImage, setSelectedImage] = useState(null);
+
+        const [previewImage, setPreviewImage] = useState(null);
+        const [isUploading, setIsUploading] = useState(false);
+
+        useEffect(() => {
+            const loadPayments = async () => {
+                if (!startedAt || !endAt) {
+                    console.log("진행 중인 콘테스트 정보가 없습니다.");
+                    return;
+                }
+
+                try {
+                    const paymentData = await fetchContestPayments(startedAt, endAt);
+                    setPayments(paymentData);
+                } catch (error) {
+                    console.error(error);
+                }
+            };
+
+            loadPayments();
+        }, [startedAt, endAt]);
+
+        const handleBack = () => {
+            if (step > 1) {
+                setStep(step - 1);
+            } else {
+                navigate(-1);
+            }
+        };
+
+        const handleImageUpload = async (file) => {
+            try {
+                setIsUploading(true);
+                const uploadedUrl = await uploadImage(file);
+
+                if (uploadedUrl) {
+                    setSelectedImage(uploadedUrl);
+                }
+            } catch (error) {
+                console.error(error);
+            }
+        };
+
+    const handleFileChange = async (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+
+        // 미리보기 설정
+        setPreviewImage(URL.createObjectURL(file));
+
+        // 이미지 업로드
+        await handleImageUpload(file);
     };
 
-    // localStorage에 전체 참여 정보 저장
-    const participatedContests = JSON.parse(
-      localStorage.getItem('participatedContests') || '[]'
-    );
-    participatedContests.push(participationInfo);
-    localStorage.setItem(
-      'participatedContests',
-      JSON.stringify(participatedContests)
-    );
-    const participatedGroomers = JSON.parse(
-      localStorage.getItem('participatedGroomers') || '[]'
-    );
-    participatedGroomers.push(selectedGroomer.id);
-    localStorage.setItem(
-      'participatedGroomers',
-      JSON.stringify(participatedGroomers)
-    );
-    navigate('/contest');
-  };
-  // 예시 데이터
-  const groomers = [
-    {
-      id: 1,
-      name: '홍길동 미용사',
-      date: '2024-11-14',
-      price: '33,000 원',
-      place: '서울, 강남구',
-    },
-    {
-      id: 2,
-      name: '홍길동 미용사',
-      date: '2024-11-14',
-      price: '33,000 원',
-      place: '서울, 강남구',
-    },
-  ];
+        const handleContestSubmit = async () => {
+            try {
+                if (!selectedGroomer) {
+                    alert("결제내역을 선택해주세요");
+                    return;
+                }
+                const participationInfo = {
+                    contestId,
+                    groomer_profile_id: selectedGroomer.groomerProfileId,
+                    dog_name: petName,
+                    image_url: selectedImage,
+                    description: explanation,
+                };
 
-  const handleGroomerSelect = (groomer) => {
-    if (selectedGroomer?.id === groomer.id) {
-      setSelectedGroomer(null);
-    } else {
-      setSelectedGroomer(groomer);
-    }
-  };
+                const response = await postContestEntry(participationInfo);
 
-  const renderStep1 = () => (
-    <Box>
-      <Typography fontSize={24} fontWeight="bold" mt={6}>
-        누구에게 받은 미용으로 콘테스트
-      </Typography>
-      <Typography fontSize={24} fontWeight="bold" mb={4}>
-        참여하실 건가요?
-      </Typography>
+                if (response === '콘테스트 참여에 성공했습니다!') {
+                    alert("콘테스트 참여가 완료되었습니다!");
+                    navigate('/contest');
+                } else {
+                    alert("참여 중 문제가 발생했습니다. 다시 시도해주세요!");
+                }
+            } catch (error) {
+                console.error(error);
+                alert("참여 중 문제가 발생했습니다. 다시 시도해주세요!");
+            }
 
-      {groomers.map((groomer) => (
-        <Box
-          key={groomer.id}
-          sx={{
-            p: 2,
-            mb: 2,
-            border:
-              selectedGroomer?.id === groomer.id ? '1px solid' : '1px solid',
-            borderColor:
-              selectedGroomer?.id === groomer.id ? 'secondary.main' : 'n4.main',
-            borderRadius: '10px',
-            cursor: 'pointer',
-            boxShadow: 'rgba(0, 0, 0, 0.05) 0px 0px 7px 1px',
-          }}
-          onClick={() => handleGroomerSelect(groomer)}
-        >
-          <Box display="flex" alignItems="center">
-            <img
-              src="/images/default-groomer-profile.png"
-              alt="groomer"
-              style={{
-                width: '100px',
-                marginRight: '12px',
-              }}
-            />
-            <Box mx={3}>
-              <Typography fontWeight={700}>{groomer.name}</Typography>
-              <Typography fontSize={14} mt={1}>
-                결제일: {groomer.date}
-              </Typography>
-              <Typography fontSize={14}>서비스: 목욕, 털미용</Typography>
-              <Typography
-                fontWeight={600}
-                color="secondary.main"
-                fontSize={18}
-                mt={1}
-              >
-                {groomer.price}
-              </Typography>
+            // // localStorage에 전체 참여 정보 저장
+            // const participatedContests = JSON.parse(
+            //     localStorage.getItem('participatedContests') || '[]'
+            // );
+            // participatedContests.push(participationInfo);
+            // localStorage.setItem(
+            //     'participatedContests',
+            //     JSON.stringify(participatedContests)
+            // );
+            // const participatedGroomers = JSON.parse(
+            //     localStorage.getItem('participatedGroomers') || '[]'
+            // );
+            // participatedGroomers.push(selectedGroomer.id);
+            // localStorage.setItem(
+            //     'participatedGroomers',
+            //     JSON.stringify(participatedGroomers)
+            // );
+            // navigate('/contest');
+        };
+        // // 예시 데이터
+        // const groomers = [
+        //   {
+        //     id: 1,
+        //     name: '홍길동 미용사',
+        //     date: '2024-11-14',
+        //     price: '33,000 원',
+        //     place: '서울, 강남구',
+        //   },
+        //   {
+        //     id: 2,
+        //     name: '홍길동 미용사',
+        //     date: '2024-11-14',
+        //     price: '33,000 원',
+        //     place: '서울, 강남구',
+        //   },
+        // ];
+
+        const handleGroomerSelect = (groomer) => {
+            if (selectedGroomer?.groomerProfileId === groomer.groomerProfileId) {
+                setSelectedGroomer(null);
+            } else {
+                setSelectedGroomer(groomer);
+            }
+        };
+
+        const renderStep1 = () => {
+            if (payments.length === 0) {
+                return <Typography>콘테스트 기간 내 결제내역이 없습니다.</Typography>;
+            }
+
+            return (
+                <Box>
+                    <Typography fontSize={24} fontWeight="bold" mt={6}>
+                        누구에게 받은 미용으로 콘테스트
+                    </Typography>
+                    <Typography fontSize={24} fontWeight="bold" mb={4}>
+                        참여하실 건가요?
+                    </Typography>
+
+                    {payments.map((payment, index) => (
+                        <Box
+                            key={index}
+                            sx={{
+                                p: 2,
+                                mb: 2,
+                                border:
+                                    selectedGroomer?.groomerProfileId === payment.groomerProfileId
+                                        ? '1px solid'
+                                        : '1px solid',
+                                borderColor:
+                                    selectedGroomer?.groomerProfileId === payment.groomerProfileId
+                                        ? 'secondary.main'
+                                        : 'n4.main',
+                                borderRadius: '10px',
+                                cursor: 'pointer',
+                                boxShadow: 'rgba(0, 0, 0, 0.05) 0px 0px 7px 1px',
+                            }}
+                            onClick={() =>
+                                handleGroomerSelect({
+                                    groomerProfileId: payment.groomerProfileId, // ID를 상태로 저장
+                                    groomerName: payment.groomerName,
+                                })
+                            }
+                        >
+                            <Box display="flex" alignItems="center">
+                                <img
+                                    src={payment.groomerImage || '/images/default-groomer-profile.png'} // 이미지 경로
+                                    alt="groomer"
+                                    style={{
+                                        width: '100px',
+                                        marginRight: '12px',
+                                    }}
+                                />
+                                <Box mx={3}>
+                                    <Typography fontWeight={700}>{payment.groomerName}</Typography>
+                                    <Typography fontSize={14} mt={1}>
+                                        결제일:{' '}
+                                        {new Date(payment.paymentDate).toLocaleDateString()}
+                                    </Typography>
+                                    <Typography fontSize={14} mt={0.5}>
+                                        예약일:{' '}
+                                        {new Date(payment.reservationDate).toLocaleDateString()}
+                                    </Typography>
+                                    <Typography fontSize={14} mt={0.5}>
+                                        서비스: {payment.serviceList.join(', ') || '서비스 정보 없음'}
+                                    </Typography>
+                                    <Typography
+                                        fontWeight={600}
+                                        color="secondary.main"
+                                        fontSize={18}
+                                        mt={1}
+                                    >
+                                        {payment.totalAmount.toLocaleString()} 원
+                                    </Typography>
+                                </Box>
+                            </Box>
+                        </Box>
+                    ))}
+                </Box>
+            );
+        };
+
+        const renderStep2 = () => (
+            <Box>
+                <Typography fontSize={20} fontWeight="bold" mt={6} mb={3}>
+                    자랑 문구와 사진을 등록해주세요.
+                </Typography>
+
+                <Typography fontSize={14} fontWeight="bold" mb={2}>
+                    반려견 이름
+                </Typography>
+                <InputText
+                    size="large"
+                    placeholder="반려견 이름을 작성해주세요"
+                    value={petName}
+                    onChange={(e) => setPetName(e.target.value)}
+                />
+
+                <Typography fontSize={14} fontWeight="bold" mt={2} mb={2}>
+                    자랑 문구
+                </Typography>
+                <InputText
+                    size="large"
+                    placeholder="자랑 문구를 작성해주세요"
+                    value={explanation}
+                    onChange={(e) => setExplanation(e.target.value)}
+                />
+
+                <Typography fontSize={14} fontWeight="bold" mt={2} mb={2}>
+                    참가 사진 (0/1)
+                </Typography>
+                <Box
+                    sx={{
+                        width: '80px',
+                        aspectRatio: '1/1',
+                        bgcolor: 'n4.main',
+                        borderRadius: '10px',
+                        display: 'flex',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        cursor: 'pointer',
+                        mb: 3,
+                    }}
+                    onClick={() => document.getElementById('imageInput').click()}
+                >
+                    {previewImage ? (
+                        <img
+                            src={previewImage}
+                            alt="preview"
+                            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                        />
+                    ) : (
+                        <ImageUploadIcon sx={{fontSize: 48, color: 'n3.main'}}/>
+                    )}
+                </Box>
+                <input
+                    type="file"
+                    id="imageInput"
+                    accept="image/*"
+                    style={{display: 'none'}}
+                    // onChange={(e) => setSelectedImage(e.target.files[0])}
+                    onChange={handleFileChange}
+                />
             </Box>
-          </Box>
-        </Box>
-      ))}
-    </Box>
-  );
-  const renderStep2 = () => (
-    <Box>
-      <Typography fontSize={20} fontWeight="bold" mt={6} mb={3}>
-        자랑 문구와 사진을 등록해주세요.
-      </Typography>
+        );
 
-      <Typography fontSize={14} fontWeight="bold" mb={2}>
-        반려견 이름
-      </Typography>
-      <InputText
-        size="large"
-        placeholder="반려견 이름을 작성해주세요"
-        value={petName}
-        onChange={(e) => setPetName(e.target.value)}
-      />
+        return (
+            <div>
+                <SurveyHeader
+                    label="콘테스트 참여하기"
+                    totalPage={2}
+                    currPage={step}
+                    backHandler={handleBack}
+                />
+                <Container maxWidth="sm" sx={{px: 2, pb: 10}}>
+                    {step === 1 ? renderStep1() : renderStep2()}
 
-      <Typography fontSize={14} fontWeight="bold" mt={2} mb={2}>
-        자랑 문구
-      </Typography>
-      <InputText
-        size="large"
-        placeholder="자랑 문구를 작성해주세요"
-        value={explanation}
-        onChange={(e) => setExplanation(e.target.value)}
-      />
-
-      <Typography fontSize={14} fontWeight="bold" mt={2} mb={2}>
-        참가 사진 (0/1)
-      </Typography>
-      <Box
-        sx={{
-          width: '80px',
-          aspectRatio: '1/1',
-          bgcolor: 'n4.main',
-          borderRadius: '10px',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          cursor: 'pointer',
-          mb: 3,
-        }}
-        onClick={() => document.getElementById('imageInput').click()}
-      >
-        <ImageUploadIcon sx={{ fontSize: 48, color: 'n3.main' }} />
-      </Box>
-      <input
-        type="file"
-        id="imageInput"
-        accept="image/*"
-        style={{ display: 'none' }}
-        onChange={(e) => setSelectedImage(e.target.files[0])}
-      />
-    </Box>
-  );
-
-  return (
-    <div>
-      <SurveyHeader
-        label="콘테스트 참여하기"
-        totalPage={2}
-        currPage={step}
-        backHandler={handleBack}
-      />
-      <Container maxWidth="sm" sx={{ px: 2, pb: 10 }}>
-        {step === 1 ? renderStep1() : renderStep2()}
-
-        <Box
-          sx={{
-            position: 'fixed',
-            bottom: 100,
-            left: 0,
-            right: 0,
-            p: 2,
-            bgcolor: 'white',
-            display: 'flex',
-            justifyContent: 'center',
-          }}
-        >
-          {step === 1 ? (
-            <Button
-              size="large"
-              backgroundColor={selectedGroomer ? 'primary' : 'n3'}
-              onClick={() => setStep(2)}
-              label="다음으로"
-              disabled={!selectedGroomer}
-            />
-          ) : (
-            <Button
-              size="large"
-              backgroundColor={selectedImage ? 'primary' : 'n3'}
-              onClick={handleContestSubmit}
-              label="저장 후 참여하기"
-              disabled={!selectedImage}
-            />
-          )}
-        </Box>
-      </Container>
-    </div>
-  );
-};
+                    <Box
+                        sx={{
+                            position: 'fixed',
+                            bottom: 100,
+                            left: 0,
+                            right: 0,
+                            p: 2,
+                            bgcolor: 'white',
+                            display: 'flex',
+                            justifyContent: 'center',
+                        }}
+                    >
+                        {step === 1 ? (
+                            <Button
+                                size="large"
+                                backgroundColor={selectedGroomer ? 'primary' : 'n3'}
+                                onClick={() => setStep(2)}
+                                label="다음으로"
+                                disabled={!selectedGroomer}
+                            />
+                        ) : (
+                            <Button
+                                size="large"
+                                backgroundColor={selectedImage ? 'primary' : 'n3'}
+                                onClick={handleContestSubmit}
+                                label="저장 후 참여하기"
+                                disabled={!selectedImage}
+                            />
+                        )}
+                    </Box>
+                </Container>
+            </div>
+        );
+    }
+;
 
 export default ContestEntry;


### PR DESCRIPTION
## 🔍 연관된 이슈

> ex) #89 

## 🔀 작업 내용

- [x] 콘테스트 조회
- [x] 콘테스트 상세조회
- [x] 콘테스트 중복 참여 체크
- [x] 콘테스트 참여 (포스트 등록)
- [x] 포스트 삭제
- [x] 포스트 좋아요/좋아요 취소
- [x] 콘테스트 참여용 결제내역 조회
- [x] 콘테스트 피드 조회 (무한스크롤 -> 어색함) 

### 📸 스크린샷 or 영상(선택)

** 무한 스크롤 조정 필요

** IDE 코드 정렬이 잘 안돼서 정렬해주면 좋을 것 같음

![image](https://github.com/user-attachments/assets/9c9ac082-cd08-468e-9126-175c840222e1)
** 여기 이미지랑 강아지 이름 이쁘게 들어가도록 조정해야 함

** 포스트 삭제 시 나타나는 모달 없이 삭제 눌렀을 때 바로 삭제되었습니다 alert 하게 해놨음 -> 수정 필요.

** 콘테스트 참여같은 부분도 참여 후 alert로 참여 완료되었습니다. 나타내고 contest 메인 페이지로 이동하게 해놨는데 이런거 대부분 다 alert 처리해놔서 수정 필요할듯.

** 포스트 삭제버튼을 로그인 된 ID값과 포스트의 userId가 일치하면 나타나게 했는데, 현재 로그인된 UserID값을 어디에 저장하는지 몰라서 임시로 변수로 1 박아놓음 -> 수정 필요

![image](https://github.com/user-attachments/assets/9d12ae3c-ae74-42de-98fd-f637487cd510)
** 피드쪽 더 이쁘게 만들어봐도 좋을 듯? 글씨체나 강아지 소개문구 등등

## 🧐 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
